### PR TITLE
Change addon root folder

### DIFF
--- a/.github/workflows/publish_addon.yml
+++ b/.github/workflows/publish_addon.yml
@@ -26,7 +26,6 @@ jobs:
         mkdir -p ${{ github.sha }}/addons
         rsync -Rr . ${{ github.sha }}/addons/GodotAnnotate
         rm -r ${{ github.sha }}/addons/GodotAnnotate/${{ github.sha }}
-        rm -r ${{ github.sha }}/addons/GodotAnnotate/examples
         zip -r GodotAnnotate.zip ./${{ github.sha }}/addons/GodotAnnotate -x "**/.*/*"
         ls -R
         

--- a/.github/workflows/publish_addon.yml
+++ b/.github/workflows/publish_addon.yml
@@ -26,7 +26,7 @@ jobs:
         mkdir -p ${{ github.sha }}/addons
         rsync -Rr . ${{ github.sha }}/addons/GodotAnnotate
         rm -r ${{ github.sha }}/addons/GodotAnnotate/${{ github.sha }}
-        zip -r GodotAnnotate.zip ./addons/GodotAnnotate -x "**/.*/*"
+        zip -r GodotAnnotate.zip ./${{ github.sha }}/addons/GodotAnnotate -x "**/.*/*"
         ls -R
         
     - name: Retrieve Release

--- a/.github/workflows/publish_addon.yml
+++ b/.github/workflows/publish_addon.yml
@@ -23,7 +23,7 @@ jobs:
       
     - name: Create Addon Folder
       run: |
-        mkdir ${{ github.sha }}/addons
+        mkdir -p ${{ github.sha }}/addons
         rsync -Rr . ${{ github.sha }}/addons/GodotAnnotate
         rm -r ${{ github.sha }}/addons/GodotAnnotate/${{ github.sha }}
         zip -r GodotAnnotate.zip ./addons/GodotAnnotate -x "**/.*/*"

--- a/.github/workflows/publish_addon.yml
+++ b/.github/workflows/publish_addon.yml
@@ -26,6 +26,7 @@ jobs:
         mkdir -p ${{ github.sha }}/addons
         rsync -Rr . ${{ github.sha }}/addons/GodotAnnotate
         rm -r ${{ github.sha }}/addons/GodotAnnotate/${{ github.sha }}
+        rm -r ${{ github.sha }}/addons/GodotAnnotate/examples
         zip -r GodotAnnotate.zip ./${{ github.sha }}/addons/GodotAnnotate -x "**/.*/*"
         ls -R
         

--- a/.github/workflows/publish_addon.yml
+++ b/.github/workflows/publish_addon.yml
@@ -23,8 +23,9 @@ jobs:
       
     - name: Create Addon Folder
       run: |
-        mkdir addons
-        rsync -Rr . addons/GodotAnnotate
+        mkdir ${{ github.sha }}/addons
+        rsync -Rr . ${{ github.sha }}/addons/GodotAnnotate
+        rm -r ${{ github.sha }}/addons/GodotAnnotate/${{ github.sha }}
         zip -r GodotAnnotate.zip ./addons/GodotAnnotate -x "**/.*/*"
         ls -R
         


### PR DESCRIPTION
Addon download now has github commit hash as root folder, to work better with godot asset library default install options.