### PR TITLE
Add storing canvas to disk as an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Use Right Mouse Button to erase annotate strokes on the currently selected 'Anno
 
 Use Shift + Mouse Scroll to quickly change the brush size.
 
+Use Shift + Alt + S to save the canvas to disk as an image.
+
 ## Links
 
 [Godot Assets](https://godotengine.org/asset-library/asset/2432)

--- a/res/CanvasImageDialog.tscn
+++ b/res/CanvasImageDialog.tscn
@@ -1,5 +1,5 @@
 [gd_scene format=3 uid="uid://bueej38g03yw2"]
 
 [node name="CanvasImageDialog" type="FileDialog"]
-title = "Select where to save canvas image"
+title = "Select Where To Save Canvas Image"
 filters = PackedStringArray("*.png, *.jpg, *.jpeg ; Images")

--- a/res/CanvasImageDialog.tscn
+++ b/res/CanvasImageDialog.tscn
@@ -1,0 +1,5 @@
+[gd_scene format=3 uid="uid://bueej38g03yw2"]
+
+[node name="CanvasImageDialog" type="FileDialog"]
+title = "Select where to save canvas image"
+filters = PackedStringArray("*.png, *.jpg, *.jpeg ; Images")

--- a/res/UpscaleFactorDialog.tscn
+++ b/res/UpscaleFactorDialog.tscn
@@ -1,0 +1,12 @@
+[gd_scene format=3 uid="uid://bkubc0dybo25h"]
+
+[node name="UpscaleFactorDialog" type="ConfirmationDialog"]
+title = "Upscale Factor"
+
+[node name="UpscaleFactorInput" type="SpinBox" parent="."]
+offset_left = 8.0
+offset_top = 8.0
+offset_right = 192.0
+offset_bottom = 51.0
+step = 0.1
+value = 1.0

--- a/res/UpscaleFactorDialog.tscn
+++ b/res/UpscaleFactorDialog.tscn
@@ -1,12 +1,20 @@
 [gd_scene format=3 uid="uid://bkubc0dybo25h"]
 
 [node name="UpscaleFactorDialog" type="ConfirmationDialog"]
-title = "Upscale Factor"
+title = "Canvas Upscale Factor"
+size = Vector2i(200, 88)
+visible = true
+min_size = Vector2i(100, 70)
 
 [node name="UpscaleFactorInput" type="SpinBox" parent="."]
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
 offset_left = 8.0
-offset_top = 8.0
+offset_top = -36.0
 offset_right = 192.0
-offset_bottom = 51.0
+offset_bottom = -5.0
+grow_vertical = 2
 step = 0.1
 value = 1.0
+alignment = 1

--- a/src/annotate_canvas.gd
+++ b/src/annotate_canvas.gd
@@ -53,6 +53,14 @@ var _erasing := false
 ## in the layer_resource array.
 var _stroke_lines: Array[AnnotateStrokeLine] = [ ]
 
+func get_canvas_area() -> Rect2:
+	var canvas_area := Rect2i()
+	
+	for stroke in layer_resource.strokes:
+		canvas_area = canvas_area.merge(stroke.boundary)
+		
+	return canvas_area
+
 func _ready():
 	if not Engine.is_editor_hint() and not show_when_running:
 		queue_free()
@@ -90,6 +98,9 @@ func _on_end_erase():
 func _on_stroke_resize(direction: float):
 	brush_size *= 1 + direction * SIZE_SCROLL_PERC
 	brush_size = min(100, max(brush_size, 1))
+
+func _on_capture_canvas(file: String, scale: float):
+	add_child(AnnotateCanvasCaptureViewport.new(self, file, scale))
 
 func _process(delta):
 	if _active_stroke:

--- a/src/annotate_canvas_capture_viewport.gd
+++ b/src/annotate_canvas_capture_viewport.gd
@@ -1,17 +1,22 @@
 class_name AnnotateCanvasCaptureViewport
 extends SubViewport
+## Class responsible for saving an image version of a AnnotateCanvas node to disk.
 
 var _first_process := true
 var _file_location: String
 
+## Construct a AnnotateCanvasCaptureViewport node. [br]
+## [param AnnotateCanvas]: AnnotateCanvas which should be saved as an image to disk.
+## [param file]: Filename the image will be stored under.
+## [param scale]: What the resolution of the image should be scaled by.
 func _init(canvas: AnnotateCanvas, file: String, scale: float = 1.0):
 	canvas = canvas.duplicate()
 	_file_location = file
 	
-	# get top, left and bottom right corner of canvas.
-	
 	var canvas_area := canvas.get_canvas_area()
 	
+	# viewports render anything from (0, 0) to (width, height),
+	# so we want to offset the canvas contents to make sure they fit inside this area.
 	canvas.position = canvas_area.position
 	canvas.scale *= scale
 	canvas_area.position = Vector2.ZERO
@@ -29,5 +34,4 @@ func _process(_delta):
 		return
 		
 	get_texture().get_image().save_png(_file_location)
-	print("CAPTURE CANVAS")
 	queue_free()

--- a/src/annotate_canvas_capture_viewport.gd
+++ b/src/annotate_canvas_capture_viewport.gd
@@ -1,0 +1,33 @@
+class_name AnnotateCanvasCaptureViewport
+extends SubViewport
+
+var _first_process := true
+var _file_location: String
+
+func _init(canvas: AnnotateCanvas, file: String, scale: float = 1.0):
+	canvas = canvas.duplicate()
+	_file_location = file
+	
+	# get top, left and bottom right corner of canvas.
+	
+	var canvas_area := canvas.get_canvas_area()
+	
+	canvas.position = canvas_area.position
+	canvas.scale *= scale
+	canvas_area.position = Vector2.ZERO
+	
+	add_child(canvas)
+	size = canvas_area.size * scale
+	
+	render_target_update_mode = SubViewport.UPDATE_ALWAYS
+	transparent_bg = true
+
+func _process(_delta):
+	if _first_process:
+		# allow viewport to update itself before capturing
+		_first_process = false
+		return
+		
+	get_texture().get_image().save_png(_file_location)
+	print("CAPTURE CANVAS")
+	queue_free()

--- a/src/godot_annotate.gd
+++ b/src/godot_annotate.gd
@@ -15,6 +15,22 @@ func _exit_tree():
 func _forward_canvas_gui_input(event):
 	if not selected_canvas or selected_canvas.lock_canvas:
 		return false
+	
+	if event is InputEventKey:
+		
+		if event.keycode == KEY_S && event.pressed && event.alt_pressed && event.shift_pressed:
+			var save_location := FileDialog.new()
+			save_location.file_mode = FileDialog.FILE_MODE_SAVE_FILE
+			save_location.mode_overrides_title = false
+			save_location.title = "Select where to save canvas image"
+			save_location.set_filters(PackedStringArray(["*.png, *.jpg, *.jpeg ; Images"]))
+			
+			save_location.file_selected.connect(func(file):
+				print(file)
+				selected_canvas._on_capture_canvas(file, 1)
+			)
+			
+			get_editor_interface().popup_dialog_centered(save_location)
 		
 	if event is InputEventMouseButton:
 		# drawing

--- a/src/godot_annotate.gd
+++ b/src/godot_annotate.gd
@@ -20,13 +20,15 @@ func _forward_canvas_gui_input(event):
 	
 	if event is InputEventKey:
 		
+		# canvas capture (shortcut: shift + alt + s)
 		if event.keycode == KEY_S && event.pressed && event.alt_pressed && event.shift_pressed:
 			var upscale_factor_dialog := upscale_factor_dialog_scene.instantiate()
 			upscale_factor_dialog.confirmed.connect(func():
 				
 				var canvas_image_dialog := canvas_image_dialog_scene.instantiate()
 				canvas_image_dialog.file_selected.connect(func(file):
-				
+					
+					# upscale factor is present in the spinbox child of the upscale factor dialog.
 					selected_canvas._on_capture_canvas(file, upscale_factor_dialog.get_child(0).value)
 				
 				)

--- a/src/godot_annotate.gd
+++ b/src/godot_annotate.gd
@@ -4,6 +4,8 @@ extends EditorPlugin
 ## Handles initialization, deinitialization and event forwarding to [AnnotateCanvas] nodes.
 
 static var selected_canvas: AnnotateCanvas
+static var canvas_image_dialog_scene := preload("../res/CanvasImageDialog.tscn")
+static var upscale_factor_dialog_scene := preload("../res/UpscaleFactorDialog.tscn")
 
 func _enter_tree():
 	add_custom_type("AnnotateCanvas", "Node2D", preload("annotate_canvas.gd"), preload("../annotate_layer.svg"))
@@ -19,18 +21,21 @@ func _forward_canvas_gui_input(event):
 	if event is InputEventKey:
 		
 		if event.keycode == KEY_S && event.pressed && event.alt_pressed && event.shift_pressed:
-			var save_location := FileDialog.new()
-			save_location.file_mode = FileDialog.FILE_MODE_SAVE_FILE
-			save_location.mode_overrides_title = false
-			save_location.title = "Select where to save canvas image"
-			save_location.set_filters(PackedStringArray(["*.png, *.jpg, *.jpeg ; Images"]))
+			var upscale_factor_dialog := upscale_factor_dialog_scene.instantiate()
+			upscale_factor_dialog.confirmed.connect(func():
+				
+				var canvas_image_dialog := canvas_image_dialog_scene.instantiate()
+				canvas_image_dialog.file_selected.connect(func(file):
+				
+					selected_canvas._on_capture_canvas(file, upscale_factor_dialog.get_child(0).value)
+				
+				)
+				
+				get_editor_interface().popup_dialog_centered(canvas_image_dialog)
 			
-			save_location.file_selected.connect(func(file):
-				print(file)
-				selected_canvas._on_capture_canvas(file, 1)
 			)
 			
-			get_editor_interface().popup_dialog_centered(save_location)
+			get_editor_interface().popup_dialog_centered(upscale_factor_dialog)
 		
 	if event is InputEventMouseButton:
 		# drawing


### PR DESCRIPTION
Allows user to store an image version of the selected AnnotateCanvas to disk, by using the Shift + Alt + S, shortcut.