### PR TITLE
Add polygon draw method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ To start annotating, add the 'AnnotateCanvas' node to a godot scene.
 
 Use Left Mouse Button to annotate on the currenty selected 'AnnotateCanvas' node.
 
+Use Alt + Left Mouse Button to annotate in polygon mode.
+
 Use Right Mouse Button to erase annotate strokes on the currently selected 'AnnotateCanvas' node.
 
 Use Shift + Mouse Scroll to quickly change the brush size.

--- a/src/godot_annotate.gd
+++ b/src/godot_annotate.gd
@@ -4,6 +4,9 @@ extends EditorPlugin
 ## Handles initialization, deinitialization and event forwarding to [AnnotateCanvas] nodes.
 
 static var selected_canvas: AnnotateCanvas
+
+static var poly_in_progress := false
+
 static var canvas_image_dialog_scene := preload("../res/CanvasImageDialog.tscn")
 static var upscale_factor_dialog_scene := preload("../res/UpscaleFactorDialog.tscn")
 
@@ -39,14 +42,29 @@ func _forward_canvas_gui_input(event):
 			
 			get_editor_interface().popup_dialog_centered(upscale_factor_dialog)
 		
+		# polygon drawing
+		if poly_in_progress:
+			if event.keycode == KEY_ALT && !event.pressed:
+				selected_canvas._on_end_stroke()
+				poly_in_progress = false
+				return true
+	
 	if event is InputEventMouseButton:
 		# drawing
 		if event.button_index == MOUSE_BUTTON_LEFT && event.pressed:
-			selected_canvas._on_begin_stroke()
+			if event.alt_pressed && !poly_in_progress:
+				selected_canvas._on_begin_stroke()
+				poly_in_progress = true
+			if poly_in_progress:
+				selected_canvas._on_draw_poly_stroke()
+			else:
+				selected_canvas._on_begin_stroke()
 			return true
 		elif event.button_index == MOUSE_BUTTON_LEFT && not event.pressed:
-			selected_canvas._on_end_stroke()
+			if !poly_in_progress:
+				selected_canvas._on_end_stroke()
 			return true
+		
 		
 		# erasing
 		elif event.button_index == MOUSE_BUTTON_RIGHT && event.pressed:


### PR DESCRIPTION
Adds a polygon drawing method, which draws a line between each user click, as long as they hold down alt.
So the shortcut for the poly method is Alt + Left Mouse Button.