### PR TITLE
Edit strokes

### DIFF
--- a/src/annotate_modes/freehand/freehand_stroke.gd
+++ b/src/annotate_modes/freehand/freehand_stroke.gd
@@ -104,6 +104,8 @@ func _set_stroke_size(size: float) -> void:
 	%StrokeLine.width = size
 
 	if _is_stroke_finished:
+		# Since scaling is performed at the origin of the first line point, we need to reposition the line so start cap is at most tangent to the strokes rect.
+		# We also need to edit the finished size to take into account the new stroke size.
 		finished_size += Vector2.ONE * (size - prev_size)
 		%StrokeLine.position = Vector2.ONE * stroke_size / 2
 		_stroke_resized()

--- a/src/annotate_modes/freehand/freehand_stroke.gd
+++ b/src/annotate_modes/freehand/freehand_stroke.gd
@@ -61,7 +61,6 @@ func _stroke_resized() -> void:
 	for child in %CollisionArea.get_children():
 		child.queue_free()
 	
-	print("MDH: ", min_distance_hitbox)
 	var capsules := AnnotateModeHelper.gen_line2d_hitbox(%StrokeLine, min_distance_hitbox)
 	
 	for capsule in capsules:

--- a/src/annotate_modes/freehand/freehand_stroke.gd
+++ b/src/annotate_modes/freehand/freehand_stroke.gd
@@ -100,7 +100,13 @@ func _stroke_finished():
 	return true
 
 func _set_stroke_size(size: float) -> void:
+	var prev_size = %StrokeLine.width
 	%StrokeLine.width = size
+
+	if _is_stroke_finished:
+		finished_size += Vector2.ONE * (size - prev_size)
+		%StrokeLine.position = Vector2.ONE * stroke_size / 2
+		_stroke_resized()
 
 func _set_stroke_color(color: Color) -> void:
 	%StrokeLine.default_color = color

--- a/src/annotate_modes/freehand/freehand_stroke.gd
+++ b/src/annotate_modes/freehand/freehand_stroke.gd
@@ -46,7 +46,7 @@ func try_annotate_point(point: Vector2, perc_min_point_dist: float, force: bool)
 	size = new_boundary.size
 
 	# since global_position has been modified,
-	# we need to re place the line origin back to world origin,
+	# we need to move the line origin back to world origin,
 	# in order to not offset the already drawn points.
 	%StrokeLine.global_position = Vector2.ZERO
 	

--- a/src/annotate_modes/freehand/freehand_stroke.gd
+++ b/src/annotate_modes/freehand/freehand_stroke.gd
@@ -14,6 +14,12 @@ const MIN_FLOAT_TRES_VAL = 0.001
 @export
 var min_distance_hitbox: float
 
+@export
+var points: PackedVector2Array
+
+@export
+var finished_size: Vector2
+
 ## Attempts to insert the given point at the end of the stroke line.
 ## If the point is less than [param perc_min_point_dist], it will not be added,
 ## unless [param force] is set to true.
@@ -61,6 +67,17 @@ func _stroke_resized() -> void:
 	for child in %CollisionArea.get_children():
 		child.queue_free()
 	
+	# Scale polygon points
+	if _is_stroke_finished:
+		var scaled_points := points.duplicate()
+
+		var scale_factor := (size - Vector2.ONE * stroke_size) / (finished_size - Vector2.ONE * stroke_size)
+
+		for i in range(len(scaled_points)):
+			scaled_points[i] = scaled_points[i] * scale_factor
+
+		%StrokeLine.points = scaled_points
+
 	var capsules := AnnotateModeHelper.gen_line2d_hitbox(%StrokeLine, min_distance_hitbox)
 	
 	for capsule in capsules:
@@ -75,6 +92,12 @@ func _stroke_created(first_point: Vector2) -> void:
 	%StrokeLine.global_position = Vector2.ZERO
 
 	%StrokeLine.add_point(first_point)
+
+func _stroke_finished():
+	AnnotateModeHelper.move_line2d_origin(%StrokeLine, Vector2.ONE * stroke_size / 2)
+	points = %StrokeLine.points
+	finished_size = size
+	return true
 
 func _set_stroke_size(size: float) -> void:
 	%StrokeLine.width = size

--- a/src/annotate_modes/freehand/freehand_stroke.gd
+++ b/src/annotate_modes/freehand/freehand_stroke.gd
@@ -65,6 +65,7 @@ func _stroke_resized() -> void:
 	# clear previous hitbox.
 
 	for child in %CollisionArea.get_children():
+		%CollisionArea.remove_child(child)
 		child.queue_free()
 	
 	# Scale polygon points

--- a/src/annotate_modes/helpers/annotate_mode_helper.gd
+++ b/src/annotate_modes/helpers/annotate_mode_helper.gd
@@ -27,6 +27,14 @@ static func expand_boundary_sized_point(boundary: Rect2, point: Vector2, size: f
 
 	return boundary
 
+## Relocate the passed lines origin, without effecting the globall position of the line points.
+## new_origin is in local space
+static func move_line2d_origin(line: Line2D, new_origin: Vector2):
+	var prev_origin = line.global_position
+	line.position = new_origin
+
+	for i in range(len(line.points)):
+		line.points[i] += prev_origin - line.global_position
 
 ## Regenerates all the CollisionShape2D nodes required for representing the strokes hitbox.
 static func gen_line2d_hitbox(line: Line2D, min_capsule_distance: float = 0.0) -> Array[CollisionShape2D]:

--- a/src/annotate_modes/polygon/polygon_stroke.gd
+++ b/src/annotate_modes/polygon/polygon_stroke.gd
@@ -84,7 +84,7 @@ func _stroke_resized():
 	if len(%Border.points) < 2:
 		return
 
-	# Update polygon points
+	# Scale polygon points
 
 	if _is_stroke_finished:
 		print(points)

--- a/src/annotate_modes/polygon/polygon_stroke.gd
+++ b/src/annotate_modes/polygon/polygon_stroke.gd
@@ -53,7 +53,15 @@ func set_cursor_pos(new_pos: Vector2):
 	%Fill.polygon = %Border.points
 
 func _set_stroke_size(size: float) -> void:
+	var prev_size = %Border.width
 	%Border.width = size
+
+	if _is_stroke_finished:
+		finished_size += Vector2.ONE * (size - prev_size)
+		%Border.position = Vector2.ONE * stroke_size / 2
+		%Fill.position = %Border.position
+		_stroke_resized()
+
 
 func _set_stroke_color(color: Color) -> void:
 	%Border.default_color = color

--- a/src/annotate_modes/polygon/polygon_stroke.gd
+++ b/src/annotate_modes/polygon/polygon_stroke.gd
@@ -57,6 +57,8 @@ func _set_stroke_size(size: float) -> void:
 	%Border.width = size
 
 	if _is_stroke_finished:
+		# Since scaling is performed at the origin of the first line point, we need to reposition the line so start cap is at most tangent to the strokes rect.
+		# We also need to edit the finished size to take into account the new stroke size.
 		finished_size += Vector2.ONE * (size - prev_size)
 		%Border.position = Vector2.ONE * stroke_size / 2
 		%Fill.position = %Border.position
@@ -95,7 +97,6 @@ func _stroke_resized():
 	# Scale polygon points
 
 	if _is_stroke_finished:
-		print(points)
 		var scaled_points := points.duplicate()
 
 		var scale_factor := (size - Vector2.ONE * stroke_size) / (finished_size - Vector2.ONE * stroke_size)

--- a/src/annotate_modes/polygon/polygon_stroke.tscn
+++ b/src/annotate_modes/polygon/polygon_stroke.tscn
@@ -11,6 +11,8 @@ size = Vector2(0, 0)
 script = ExtResource("2_rc0qe")
 fill = false
 closed = true
+points = PackedVector2Array()
+finished_size = Vector2(0, 0)
 
 [node name="Border" type="Line2D" parent="." index="0"]
 unique_name_in_owner = true

--- a/src/annotate_modes/polygon/polygon_stroke.tscn
+++ b/src/annotate_modes/polygon/polygon_stroke.tscn
@@ -22,7 +22,6 @@ default_color = Color(0, 0, 0, 1)
 joint_mode = 2
 begin_cap_mode = 2
 end_cap_mode = 2
-sharp_limit = 530.18
 
 [node name="Fill" type="Polygon2D" parent="." index="1"]
 unique_name_in_owner = true

--- a/src/canvas/annotate_canvas.gd
+++ b/src/canvas/annotate_canvas.gd
@@ -194,6 +194,7 @@ func on_editor_input(event: InputEvent) -> bool:
 				# Stroke was already added at this point, so we do not want to execute redo_stroke.
 				ur.commit_action(false)
 			else:
+				_remove_stroke_nodes([_active_stroke])
 				_active_stroke.queue_free()
 
 			_active_stroke = null

--- a/src/stroke/stroke.gd
+++ b/src/stroke/stroke.gd
@@ -145,4 +145,6 @@ func _on_resized() -> void:
 	# we do not want to notify the stroke of it being resized during annotation.
 	if _is_stroke_finished:
 		_stroke_resized()
-		on_stroke_changed()
+
+func _on_item_rect_changed() -> void:
+	on_stroke_changed()

--- a/src/stroke/stroke.gd
+++ b/src/stroke/stroke.gd
@@ -18,7 +18,7 @@ var stroke_size: float:
 			await ready
 
 		_set_stroke_size(stroke_size)
-	
+
 	get:
 		return stroke_size
 
@@ -32,11 +32,21 @@ var stroke_color: Color:
 			await ready
 
 		_set_stroke_color(stroke_color)
-	
+
 	get:
 		return stroke_color
 
+var _saved_stroke: PackedScene
+
 var _is_stroke_finished := true
+
+
+## Load a GDA_Stroke from the passed scene.
+## This should be the used in favor of saved_stroke.instantiate(), if any PackedScene functionallity is used.
+static func load_stroke(saved_stroke: PackedScene):
+	var stroke = saved_stroke.instantiate()
+	stroke._saved_stroke = saved_stroke
+	return stroke
 
 func _ready() -> void:
 	_stroke_resized()
@@ -45,12 +55,22 @@ func _ready() -> void:
 ## Should only be called when the stroke is first created, and not when instantiated from a PackedScene saved to a canvas.
 func stroke_init(stroke_size: float, stroke_color: Color, first_point: Vector2) -> void:
 	_is_stroke_finished = false
-	
+	_saved_stroke = PackedScene.new()
+
 	ready.connect(func():
 		self.stroke_size = stroke_size
 		self.stroke_color = stroke_color
 		_stroke_created(first_point)
 		)
+
+## Packs stroke into scene passed to stroke_init or load_stroke and returns the PackedScene.
+func save_stroke() -> PackedScene:
+	_saved_stroke.pack(self)
+	return get_saved_stroke()
+
+## Returns packed scene passed to stroke_init or load_stroke.
+func get_saved_stroke() -> PackedScene:
+	return _saved_stroke
 
 ## Finish annotating the stroke.
 ## After this has been called, the stroke should only be modified by changing the
@@ -60,7 +80,7 @@ func stroke_finished() -> bool:
 
 	var update_stroke := func():
 		_stroke_resized()
-		stroke_changed.emit(self)
+		on_stroke_changed()
 
 	update_stroke.call_deferred()
 
@@ -82,11 +102,15 @@ func collides_with_circle(circle: CircleShape2D, transform: Transform2D) -> bool
 
 		if shape != null && circle.collide(transform, shape.shape, shape.get_global_transform()):
 			return true
-	
+
 	return false
 
 func get_collision_area() -> Area2D:
 	return %CollisionArea
+
+func on_stroke_changed():
+	save_stroke()
+	stroke_changed.emit(self)
 
 ## Virtual method calledwhenever the stroke is created for the first time, at the given point.
 func _stroke_created(first_point: Vector2) -> void:
@@ -117,8 +141,8 @@ func _on_resized() -> void:
 	# update the boundary shape to match the new size of the Stroke control node
 	%BoundaryShape.shape.size = size
 	%BoundaryShape.position = size / 2
-	
+
 	# we do not want to notify the stroke of it being resized during annotation.
 	if _is_stroke_finished:
 		_stroke_resized()
-		stroke_changed.emit()
+		on_stroke_changed()

--- a/src/stroke/stroke.gd
+++ b/src/stroke/stroke.gd
@@ -18,7 +18,7 @@ var stroke_size: float:
 			await ready
 
 		_set_stroke_size(stroke_size)
-
+		on_stroke_changed()
 	get:
 		return stroke_size
 
@@ -32,7 +32,7 @@ var stroke_color: Color:
 			await ready
 
 		_set_stroke_color(stroke_color)
-
+		on_stroke_changed()
 	get:
 		return stroke_color
 

--- a/src/stroke/stroke.tscn
+++ b/src/stroke/stroke.tscn
@@ -24,4 +24,5 @@ collision_mask = 0
 unique_name_in_owner = true
 shape = SubResource("RectangleShape2D_v60vi")
 
+[connection signal="item_rect_changed" from="." to="." method="_on_item_rect_changed"]
 [connection signal="resized" from="." to="." method="_on_resized"]


### PR DESCRIPTION
Allow editing of strokes after they have been finished.

Adds the following:

- Select strokes in canvas whilst canvas is focused.
- Draw on canvas whilst a stroke is selected
- Resize stroke after it has finished.
- Change colour and stroke size (width of stroke) after it has finished.
- Also fixed various bugs related to hitbox generation.