### PR TITLE
Fix brush draw order

### DIFF
--- a/src/stroke/stroke.gd
+++ b/src/stroke/stroke.gd
@@ -50,6 +50,7 @@ static func load_stroke(saved_stroke: PackedScene):
 
 func _ready() -> void:
 	_stroke_resized()
+	show_behind_parent = true
 
 ## Initialize a stroke with the given stroke size, color and starting position.
 ## Should only be called when the stroke is first created, and not when instantiated from a PackedScene saved to a canvas.

--- a/src/stroke/stroke.tscn
+++ b/src/stroke/stroke.tscn
@@ -7,6 +7,7 @@ resource_local_to_scene = true
 size = Vector2(0, 0)
 
 [node name="Stroke" type="Control"]
+show_behind_parent = true
 layout_mode = 3
 anchors_preset = 0
 script = ExtResource("1_3blkm")


### PR DESCRIPTION
All strokes of AnnotateCanvas now sets their "show_behind_parent" property, ensuring the canvases draw graphics are shown on top of them.